### PR TITLE
Fix tmp path default and added PERCY_TMP_DIR support

### DIFF
--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -113,7 +113,7 @@ public class AppPercy {
             log("Error taking screenshot " + name);
             log(e.toString(), "debug");
             if (!ignoreErrors) {
-                throw new RuntimeException("Error taking screenshot " + name);
+                throw new RuntimeException("Error taking screenshot " + name, e);
             }
         }
     }

--- a/src/main/java/io/percy/appium/providers/GenericProvider.java
+++ b/src/main/java/io/percy/appium/providers/GenericProvider.java
@@ -2,6 +2,9 @@ package io.percy.appium.providers;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -38,7 +41,7 @@ public class GenericProvider {
         return tag;
     }
 
-    public List<Tile> captureTiles(Boolean fullScreen) {
+    public List<Tile> captureTiles(Boolean fullScreen) throws IOException {
         Integer statusBar = metadata.statBarHeight();
         Integer navBar = metadata.navBarHeight();
         String srcString = captureScreenshot();
@@ -54,25 +57,30 @@ public class GenericProvider {
         return true;
     }
 
-    private String getAbsolutePath(String srcString) {
-        String dirPath = getDirPath();
-        String filePath = dirPath + UUID.randomUUID().toString() + ".png";
+    private String getAbsolutePath(String srcString) throws IOException {
+        Path dirPath = getDirPath();
+        String filePath = Paths.get(
+            dirPath.toString(), UUID.randomUUID().toString() + ".png").toAbsolutePath().toString();
         try {
             byte[] data = Base64.decodeBase64(srcString);
             FileOutputStream outputStream = new FileOutputStream(filePath);
             outputStream.write(data);
             outputStream.close();
         } catch (IOException e) {
-            AppPercy.log("Failed to write to file");
+            AppPercy.log("Failed to write to file: " + filePath);
+            throw e;
         }
         return filePath;
     }
 
-    private String getDirPath() {
+    private Path getDirPath() throws IOException {
         String tempDir = System.getenv().getOrDefault("PERCY_TMP_DIR", null); 
-        if (tempDir != null) return tempDir;
-
-        return System.getProperty("java.io.tmpdir");
+        if (tempDir == null) { 
+            tempDir = System.getProperty("java.io.tmpdir");
+        }
+        Path tempDirPath = Paths.get(tempDir);
+        Files.createDirectories(tempDirPath);
+        return tempDirPath;
     }
 
     private String captureScreenshot() {
@@ -80,12 +88,12 @@ public class GenericProvider {
     }
 
     public String screenshot(String name, String deviceName, Integer statusBarHeight, Integer navBarHeight,
-            String orientation, Boolean fullScreen, String debugUrl) {
+            String orientation, Boolean fullScreen, String debugUrl) throws IOException {
         return screenshot(name, deviceName, statusBarHeight, navBarHeight, orientation, fullScreen, debugUrl, null);
     }
 
     public String screenshot(String name, String deviceName, Integer statusBarHeight, Integer navBarHeight,
-            String orientation, Boolean fullScreen, String debugUrl, String platformVersion) {
+            String orientation, Boolean fullScreen, String debugUrl, String platformVersion) throws IOException {
         this.metadata = MetadataHelper.resolve(driver, deviceName, statusBarHeight, navBarHeight, orientation,
                 platformVersion);
         JSONObject tag = getTag();

--- a/src/main/java/io/percy/appium/providers/GenericProvider.java
+++ b/src/main/java/io/percy/appium/providers/GenericProvider.java
@@ -69,12 +69,10 @@ public class GenericProvider {
     }
 
     private String getDirPath() {
-        String os = System.getProperty("os.name");
-        if (os.contains("Mac") || os.contains("Linux")) {
-            return "/tmp/";
-        } else {
-            return "C:\\Users\\AppData\\Local\\Temp\\";
-        }
+        String tempDir = System.getenv().getOrDefault("PERCY_TMP_DIR", null); 
+        if (tempDir != null) return tempDir;
+
+        return System.getProperty("java.io.tmpdir");
     }
 
     private String captureScreenshot() {

--- a/src/main/java/io/percy/appium/providers/GenericProvider.java
+++ b/src/main/java/io/percy/appium/providers/GenericProvider.java
@@ -74,8 +74,8 @@ public class GenericProvider {
     }
 
     private Path getDirPath() throws IOException {
-        String tempDir = System.getenv().getOrDefault("PERCY_TMP_DIR", null); 
-        if (tempDir == null) { 
+        String tempDir = System.getenv().getOrDefault("PERCY_TMP_DIR", null);
+        if (tempDir == null) {
             tempDir = System.getProperty("java.io.tmpdir");
         }
         Path tempDirPath = Paths.get(tempDir);

--- a/src/test/java/io/percy/appium/providers/AppAutomateTest.java
+++ b/src/test/java/io/percy/appium/providers/AppAutomateTest.java
@@ -59,7 +59,7 @@ public class AppAutomateTest {
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }
-        Assert.assertEquals(appAutomate.supports(androidDriver), true);
+        Assert.assertEquals(AppAutomate.supports(androidDriver), true);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AppAutomateTest {
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }
-        Assert.assertEquals(appAutomate.supports(androidDriver), false);
+        Assert.assertEquals(AppAutomate.supports(androidDriver), false);
     }
 
     @Test

--- a/src/test/java/io/percy/appium/providers/GenericProviderTest.java
+++ b/src/test/java/io/percy/appium/providers/GenericProviderTest.java
@@ -77,7 +77,7 @@ public class GenericProviderTest {
         genericProvider.setMetadata(new AndroidMetadata(androidDriver, null, null, null, null, null));
 
         Tile tile = genericProvider.captureTiles(false).get(0);
-        Assert.assertTrue(tile.getLocalFilePath().contains("/tmp"));
+        Assert.assertTrue(tile.getLocalFilePath().endsWith(".png"));
         Assert.assertEquals(tile.getStatusBarHeight().intValue(), top.intValue());
         Assert.assertEquals(tile.getNavBarHeight().intValue(), 2160 - (height + top));
         Assert.assertEquals(tile.getHeaderHeight().intValue(), 0);
@@ -87,8 +87,7 @@ public class GenericProviderTest {
 
     @Test
     public void testSupports() {
-        GenericProvider genericProvider = new GenericProvider(androidDriver);
-        Assert.assertEquals(genericProvider.supports(androidDriver), true);
+        Assert.assertEquals(GenericProvider.supports(androidDriver), true);
     }
 
     @Test

--- a/src/test/java/io/percy/appium/providers/GenericProviderTest.java
+++ b/src/test/java/io/percy/appium/providers/GenericProviderTest.java
@@ -6,6 +6,7 @@ import io.percy.appium.metadata.AndroidMetadata;
 
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.HashMap;
 
 import org.json.JSONObject;
@@ -64,7 +65,7 @@ public class GenericProviderTest {
     }
 
     @Test
-    public void testcaptureTiles() {
+    public void testcaptureTiles() throws IOException {
         viewportRect.put("top", top);
         viewportRect.put("height", height);
         sessionValue.put("viewportRect", viewportRect);


### PR DESCRIPTION
- Now uses `java.io.tmpdir` to get temp directory across all envs
- Implemented an env var PERCY_TMP_DIR to customize temp dir
- Improved error handling and logging