### PR TITLE
Add support for percy app:exec start/stop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.14</version>
     </dependency>
+    <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>3.0.0-beta-8</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/io/percy/appium/lib/CliWrapper.java
+++ b/src/main/java/io/percy/appium/lib/CliWrapper.java
@@ -2,6 +2,7 @@ package io.percy.appium.lib;
 
 import java.util.List;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -18,8 +19,10 @@ import io.percy.appium.Environment;
 
 public class CliWrapper {
     // Maybe get the CLI server address
-    private static String PERCY_SERVER_ADDRESS = System.getenv().getOrDefault("PERCY_SERVER_ADDRESS",
+    public static String PERCY_SERVER_ADDRESS = System.getenv().getOrDefault("PERCY_SERVER_ADDRESS",
             "http://localhost:5338");
+    public static String PERCY_BUILD_ID;
+    public static String PERCY_BUILD_URL;
 
     // Environment information like Java, driver, & SDK versions
     private Environment env;
@@ -39,6 +42,12 @@ public class CliWrapper {
             // Executing the Get request
             HttpResponse response = httpClient.execute(httpget);
             int statusCode = response.getStatusLine().getStatusCode();
+            HttpEntity entity = response.getEntity();
+            String responseString = EntityUtils.toString(entity, "UTF-8");
+            JSONObject myObject = new JSONObject(responseString);
+            JSONObject buildJsonObject = (JSONObject) myObject.get("build");
+            PERCY_BUILD_ID = (String) buildJsonObject.get("id");
+            PERCY_BUILD_URL = (String) buildJsonObject.get("url");
 
             if (statusCode != 200) {
                 throw new RuntimeException("Failed with HTTP error code : " + statusCode);

--- a/src/main/java/io/percy/appium/providers/AppAutomate.java
+++ b/src/main/java/io/percy/appium/providers/AppAutomate.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 
 import io.appium.java_client.AppiumDriver;
 import io.percy.appium.AppPercy;
+import io.percy.appium.lib.CliWrapper;
 import io.percy.appium.lib.ScreenshotOptions;
 import io.percy.appium.lib.Tile;
 
@@ -43,8 +44,8 @@ public class AppAutomate extends GenericProvider {
             if (markedPercySession) {
                 JSONObject arguments = new JSONObject();
                 arguments.put("state", "begin");
-                arguments.put("percyBuildId", System.getenv("PERCY_BUILD_ID"));
-                arguments.put("percyBuildUrl", System.getenv("PERCY_BUILD_URL"));
+                arguments.put("percyBuildId", CliWrapper.PERCY_BUILD_ID);
+                arguments.put("percyBuildUrl", CliWrapper.PERCY_BUILD_URL);
                 arguments.put("name", name);
                 JSONObject reqObject = new JSONObject();
                 reqObject.put("action", "percyScreenshot");
@@ -96,7 +97,7 @@ public class AppAutomate extends GenericProvider {
             args.put("scollableXpath", options.getScrollableXpath());
             args.put("scrollableId", options.getScrollableId());
             arguments.put("state", "screenshot");
-            arguments.put("percyBuildId", System.getenv("PERCY_BUILD_ID"));
+            arguments.put("percyBuildId", CliWrapper.PERCY_BUILD_ID);
             arguments.put("screenshotType", "fullpage");
             arguments.put("scaleFactor", scaleFactor);
             arguments.put("options", args);

--- a/src/test/java/io/percy/appium/lib/CliWrapperTest.java
+++ b/src/test/java/io/percy/appium/lib/CliWrapperTest.java
@@ -1,0 +1,49 @@
+package io.percy.appium.lib;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.appium.java_client.android.AndroidDriver;
+
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
+public class CliWrapperTest {
+    WireMockServer server = new WireMockServer(5338);
+    @Mock
+    AndroidDriver androidDriver;
+    @Before
+    public void setup() throws JSONException {
+        CliWrapper.PERCY_SERVER_ADDRESS = "http://127.0.0.1:5338";
+        JSONObject responseJsonObject = new JSONObject();
+        JSONObject buildObject = new JSONObject();
+        buildObject.put("id", "27591981");
+        buildObject.put("url", "https://percy.io/9560f98d/app-proj-temp/builds/27591981");
+        responseJsonObject.put("build", buildObject);
+        ResponseDefinitionBuilder mockResponse = new ResponseDefinitionBuilder();
+        mockResponse.withHeader("x-percy-core-version", "1.2");
+        mockResponse.withStatus(200);
+        mockResponse.withBody(String.valueOf(responseJsonObject));
+        server.start();
+        WireMock.configureFor("127.0.0.1", 5338);
+        WireMock.stubFor(
+                WireMock.get("/percy/healthcheck")
+                        .willReturn(mockResponse)
+        );
+    }
+
+    @Test
+    public void testHealthcheck() {
+        CliWrapper cliWrapper = new CliWrapper(androidDriver);
+        cliWrapper.healthcheck();
+        Assert.assertEquals(CliWrapper.PERCY_BUILD_ID, "27591981");
+        Assert.assertEquals(CliWrapper.PERCY_BUILD_URL, "https://percy.io/9560f98d/app-proj-temp/builds/27591981");
+    }
+}

--- a/src/test/java/io/percy/appium/providers/AppAutomateTest.java
+++ b/src/test/java/io/percy/appium/providers/AppAutomateTest.java
@@ -21,6 +21,7 @@ import com.github.javafaker.Faker;
 
 import io.appium.java_client.android.AndroidDriver;
 import io.percy.appium.lib.Cache;
+import io.percy.appium.lib.CliWrapper;
 import io.percy.appium.lib.ScreenshotOptions;
 import io.percy.appium.lib.Tile;
 import io.percy.appium.metadata.AndroidMetadata;
@@ -161,8 +162,8 @@ public class AppAutomateTest {
         String name = "First";
         JSONObject arguments = new JSONObject();
         arguments.put("state", "begin");
-        arguments.put("percyBuildId", System.getenv("PERCY_BUILD_ID"));
-        arguments.put("percyBuildUrl", System.getenv("PERCY_BUILD_URL"));
+        arguments.put("percyBuildId", CliWrapper.PERCY_BUILD_ID);
+        arguments.put("percyBuildUrl", CliWrapper.PERCY_BUILD_URL);
         arguments.put("name", name);
         JSONObject reqObject = new JSONObject();
         reqObject.put("action", "percyScreenshot");
@@ -201,7 +202,7 @@ public class AppAutomateTest {
         args.put("numOfTiles", 4);
         args.put("deviceHeight", 2160);
         arguments.put("state", "screenshot");
-        arguments.put("percyBuildId", System.getenv("PERCY_BUILD_ID"));
+        arguments.put("percyBuildId", CliWrapper.PERCY_BUILD_ID);
         arguments.put("screenshotType", "fullpage");
         arguments.put("scaleFactor", 1);
         arguments.put("options", args);


### PR DESCRIPTION
- JIRA: https://browserstack.atlassian.net/browse/PAPP-269
- Read percy build id and url from healthcheck endpoint and pass to browserstack executor -> mark session as percy session, return debug URL.