### PR TITLE
:bookmark: v2.0.0-beta.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-appium-app</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
+  <version>2.0.0-beta.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -4,7 +4,7 @@ import io.appium.java_client.AppiumDriver;
 
 public class Environment {
     private AppiumDriver driver;
-    public static final String SDK_VERSION = "1.1.3";
+    public static final String SDK_VERSION = "2.0.0-beta.0";
     private static final String SDK_NAME = "percy-appium-app";
     private static String percyBuildID;
     private static String percyBuildUrl;


### PR DESCRIPTION
Releasing PoA Support, hence bumping up SDK version to `v2.0.0-beta.0`