### PR TITLE
making singlepage call to remote by default

### DIFF
--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -46,6 +46,14 @@ public class Environment {
         return System.getenv().getOrDefault("FORCE_FULL_PAGE", "false").equals("true");
     }
 
+    public static Boolean getDisableRemoteUploads() {
+        return System.getenv().getOrDefault("PERCY_DISABLE_REMOTE_UPLOADS", "false").equals("true");
+    }
+
+    public static Boolean getEnablePercyDev() {
+        return System.getenv().getOrDefault("PERCY_ENABLE_DEV", "false").equals("true");
+    }
+
     public static String getSessionType() {
         return sessionType;
     }

--- a/src/main/java/io/percy/appium/providers/AppAutomate.java
+++ b/src/main/java/io/percy/appium/providers/AppAutomate.java
@@ -91,6 +91,15 @@ public class AppAutomate extends GenericProvider {
     public String executePercyScreenshot(ScreenshotOptions options, Integer scaleFactor,
             Integer deviceHeight) throws Exception {
         try {
+            String screenshotType = "fullpage";
+            if (!options.getFullPage() || !verifyCorrectAppiumVersion()) {
+                screenshotType = "singlepage";
+            }
+            String projectId = "percy-prod";
+            if (Environment.getEnablePercyDev())
+            {
+                projectId = "percy-dev";
+            }
             JSONObject arguments = new JSONObject();
             JSONObject args = new JSONObject();
             args.put("numOfTiles", options.getScreenLengths());
@@ -100,8 +109,9 @@ public class AppAutomate extends GenericProvider {
             args.put("FORCE_FULL_PAGE", Environment.getForceFullPage());
             arguments.put("state", "screenshot");
             arguments.put("percyBuildId", Environment.getPercyBuildID());
-            arguments.put("screenshotType", "fullpage");
+            arguments.put("screenshotType", screenshotType);
             arguments.put("scaleFactor", scaleFactor);
+            arguments.put("projectId", projectId);
             arguments.put("options", args);
             JSONObject reqObject = new JSONObject();
             reqObject.put("action", "percyScreenshot");
@@ -116,7 +126,7 @@ public class AppAutomate extends GenericProvider {
     }
 
     public List<Tile> captureTiles(ScreenshotOptions options) throws Exception {
-        if (!options.getFullPage() || !verifyCorrectAppiumVersion()) {
+        if (Environment.getDisableRemoteUploads()) {
             return super.captureTiles(options);
         }
 

--- a/src/test/java/io/percy/appium/providers/AppAutomateTest.java
+++ b/src/test/java/io/percy/appium/providers/AppAutomateTest.java
@@ -110,19 +110,36 @@ public class AppAutomateTest {
     public void testcaptureTilesForSinglePage() throws Exception {
         ScreenshotOptions options = new ScreenshotOptions();
         options.setFullPage(false);
-        when(androidDriver.getScreenshotAs(OutputType.BASE64))
-                .thenReturn("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAADwCAYAAAA+VemSAAAgAEl...==");
+        String response = "{\"result\":\"[{'header_height': 200, 'footer_height': 100, 'sha': 'sha'}]\"}";
+        JSONObject arguments = new JSONObject();
+        JSONObject args = new JSONObject();
+        args.put("numOfTiles", 4);
+        args.put("deviceHeight", 2160);
+        args.put("FORCE_FULL_PAGE", false);
+
+        arguments.put("state", "screenshot");
+        arguments.put("percyBuildId", Environment.getPercyBuildID());
+        arguments.put("screenshotType", "singlepage");
+        arguments.put("projectId", "percy-prod");
+        arguments.put("scaleFactor", 1);
+        arguments.put("options", args);
+        JSONObject reqObject = new JSONObject();
+        reqObject.put("action", "percyScreenshot");
+        reqObject.put("arguments", arguments);
+
+        when(androidDriver.executeScript(String.format("browserstack_executor: %s", reqObject.toString())))
+                .thenReturn(response);
 
         AppAutomate appAutomateProvider = new AppAutomate(androidDriver);
         appAutomateProvider.setMetadata(new AndroidMetadata(androidDriver, null, null, null, null, null));
 
         Tile tile = appAutomateProvider.captureTiles(options).get(0);
-        Assert.assertTrue(tile.getLocalFilePath().endsWith(".png"));
         Assert.assertEquals(tile.getStatusBarHeight().intValue(), top.intValue());
         Assert.assertEquals(tile.getNavBarHeight().intValue(), 2160 - (height + top));
-        Assert.assertEquals(tile.getHeaderHeight().intValue(), 0);
-        Assert.assertEquals(tile.getFooterHeight().intValue(), 0);
+        Assert.assertEquals(tile.getHeaderHeight().intValue(), 200);
+        Assert.assertEquals(tile.getFooterHeight().intValue(), 100);
         Assert.assertEquals(tile.getFullScreen(), false);
+        Assert.assertEquals(tile.getSha(), "sha");
     }
 
     @Test
@@ -137,6 +154,7 @@ public class AppAutomateTest {
         arguments.put("state", "screenshot");
         arguments.put("percyBuildId", Environment.getPercyBuildID());
         arguments.put("screenshotType", "fullpage");
+        arguments.put("projectId", "percy-prod");
         arguments.put("scaleFactor", 1);
         arguments.put("options", args);
         JSONObject reqObject = new JSONObject();
@@ -209,6 +227,7 @@ public class AppAutomateTest {
         arguments.put("state", "screenshot");
         arguments.put("percyBuildId", Environment.getPercyBuildID());
         arguments.put("screenshotType", "fullpage");
+        arguments.put("projectId", "percy-prod");
         arguments.put("scaleFactor", 1);
         arguments.put("options", args);
         JSONObject reqObject = new JSONObject();


### PR DESCRIPTION
Taking singlepage ss for app automate from mobile.
Adding `PERCY_DISABLE_REMOTE_UPLOADS` env variable to override above.
Adding `PERCY_ENABLE_DEV` for dev. Added it so we can test better with sdk.