### PR TITLE
Sync CLI response fix for AppPercy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "@percy/cli": "^1.27.0-beta.1"
+    "@percy/cli": "^1.28.0-beta.0"
   }
 }

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -104,7 +104,6 @@ public class AppPercy extends IPercy {
      */
     @Override
     public JSONObject screenshot(String name, Boolean fullScreen, ScreenshotOptions options) {
-        System.out.println("==> GOJO" + isPercyEnabled + " - " + !percyOptions.percyOptionEnabled());
         if (!isPercyEnabled || !percyOptions.percyOptionEnabled()) {
             return null;
         }

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -158,11 +158,11 @@ public class AppPercy extends IPercy {
         this.cliWrapper = cli;
     }
 
-    protected void setPercyEnabled(){
+    protected void setPercyEnabled() {
         this.isPercyEnabled = true;
     }
 
-    protected void setGenericProvider(GenericProvider provider) {
-        this.provider = provider;
+    protected void setGenericProvider(GenericProvider genericProvider) {
+        this.provider = genericProvider;
     }
 }

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -26,6 +26,7 @@ public class AppPercy extends IPercy {
 
     private PercyOptions percyOptions;
 
+    private GenericProvider provider;
     /**
      * Determine if we're debug logging
      */
@@ -55,6 +56,7 @@ public class AppPercy extends IPercy {
         this.percyOptions = new PercyOptions(driver);
         this.isPercyEnabled = cliWrapper.healthcheck();
         this.sessionId = driver.getSessionId().toString();
+        this.provider = ProviderResolver.resolveProvider(driver);
     }
 
     /**
@@ -107,7 +109,6 @@ public class AppPercy extends IPercy {
         }
         percyOptions.setPercyIgnoreErrors();
         try {
-            GenericProvider provider = ProviderResolver.resolveProvider(driver);
             if (options == null) {
                 options = new ScreenshotOptions();
             }
@@ -151,4 +152,12 @@ public class AppPercy extends IPercy {
         }
     }
 
+    // Following methods added for test cases.
+    protected void setCliWrapper(CliWrapper cli) {
+        this.cliWrapper = cli;
+    }
+
+    protected void setGenericProvider(GenericProvider gProvider){
+        this.provider = gProvider;
+    }
 }

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -104,6 +104,7 @@ public class AppPercy extends IPercy {
      */
     @Override
     public JSONObject screenshot(String name, Boolean fullScreen, ScreenshotOptions options) {
+        System.out.println("==> GOJO" + isPercyEnabled + " - " + !percyOptions.percyOptionEnabled());
         if (!isPercyEnabled || !percyOptions.percyOptionEnabled()) {
             return null;
         }
@@ -157,7 +158,11 @@ public class AppPercy extends IPercy {
         this.cliWrapper = cli;
     }
 
-    protected void setGenericProvider(GenericProvider gProvider) {
-        this.provider = gProvider;
+    protected void setPercyEnabled(){
+        this.isPercyEnabled = true;
+    }
+
+    protected void setGenericProvider(GenericProvider provider) {
+        this.provider = provider;
     }
 }

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -112,7 +112,12 @@ public class AppPercy extends IPercy {
                 options = new ScreenshotOptions();
             }
             options.setFullScreen(fullScreen);
-            return provider.screenshot(name, options).getJSONObject("data");
+            JSONObject response = provider.screenshot(name, options);
+            if (response != null && response.has("data")) {
+                return response.getJSONObject("data");
+            }
+
+            return null;
         } catch (Exception e) {
             cliWrapper.postFailedEvent(e.getMessage());
             log("Error taking screenshot " + name);

--- a/src/main/java/io/percy/appium/AppPercy.java
+++ b/src/main/java/io/percy/appium/AppPercy.java
@@ -157,7 +157,7 @@ public class AppPercy extends IPercy {
         this.cliWrapper = cli;
     }
 
-    protected void setGenericProvider(GenericProvider gProvider){
+    protected void setGenericProvider(GenericProvider gProvider) {
         this.provider = gProvider;
     }
 }

--- a/src/main/java/io/percy/appium/providers/AppAutomate.java
+++ b/src/main/java/io/percy/appium/providers/AppAutomate.java
@@ -168,9 +168,6 @@ public class AppAutomate extends GenericProvider {
         try {
             JSONObject response = super.screenshot(name, options, osVersion, device);
             percyScreenshotUrl = response.getString("link");
-            if (response != null && response.has("data")) {
-                return response.getJSONObject("data");
-            }
             return response;
         } catch (Exception e) {
             error = e.getMessage();

--- a/src/test/java/io/percy/appium/AppPercyTest.java
+++ b/src/test/java/io/percy/appium/AppPercyTest.java
@@ -51,7 +51,6 @@ public class AppPercyTest{
     @Test
     public void takeScreenshotWithoutPercyEnabled() throws Exception {
       when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
-      when(androidDriver.getCapabilities()).thenReturn(capabilities);
       
       try {
         lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));

--- a/src/test/java/io/percy/appium/AppPercyTest.java
+++ b/src/test/java/io/percy/appium/AppPercyTest.java
@@ -83,6 +83,7 @@ public class AppPercyTest{
       // The CLI response is in the format { data: { snapshot-name: 'some_Test', ... and so on } }
       // We need to extract and use the response from the `data` key
       JSONObject res = percy.screenshot("Test", options);
+      System.out.println(" GOJO " + res);
       assertEquals(res.getString("snapshot-name"), "Test");
     }
 }

--- a/src/test/java/io/percy/appium/AppPercyTest.java
+++ b/src/test/java/io/percy/appium/AppPercyTest.java
@@ -1,0 +1,88 @@
+package io.percy.appium;
+
+import io.percy.appium.lib.ScreenshotOptions;
+import io.percy.appium.providers.GenericProvider;
+
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.AndroidElement;
+
+import org.openqa.selenium.remote.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
+public class AppPercyTest{
+    @Mock
+    AndroidDriver<AndroidElement> androidDriver;
+    private static AppPercy percy;
+    GenericProvider genericProvider;
+    private DesiredCapabilities capabilities;
+
+    @Before
+    public void setup() {
+        androidDriver = mock(AndroidDriver.class);
+        capabilities = new DesiredCapabilities();
+        capabilities.setCapability("browserstack.user", "USER_NAME");
+        capabilities.setCapability("browserstack.key", "USER_AUTH_KEY");
+        capabilities.setCapability("browserstack.appium_version", "1.20.2");
+        capabilities.setCapability("app", "APP_URL");
+        capabilities.setCapability("device", "DEVICE_NAME");
+        capabilities.setCapability("os_version", "9.0");
+        genericProvider = mock(GenericProvider.class);
+    }
+
+    @Test
+    public void takeScreenshotWithoutOptions() throws Exception {
+      when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
+      when(androidDriver.getCapabilities()).thenReturn(capabilities);
+
+      try {
+          lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));
+      } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+      }
+
+      percy = spy(new AppPercy(androidDriver));
+      percy.setGenericProvider(genericProvider);
+    
+      when(genericProvider.screenshot(any(), any())).thenReturn(null);
+      JSONObject res = percy.screenshot("Test");
+      assertEquals(res, null);
+    }
+
+    @Test
+    public void takeScreenshotWithSyncOption() throws Exception{
+      when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
+      when(androidDriver.getCapabilities()).thenReturn(capabilities);
+
+      try {
+          lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));
+      } catch (MalformedURLException e) {
+          throw new RuntimeException(e);
+      }
+
+      percy = spy(new AppPercy(androidDriver));
+      percy.setGenericProvider(genericProvider);
+      JSONObject mockResponse = new JSONObject()
+      .put("data", new JSONObject().put("snapshot-name", "Test"));
+      when(genericProvider.screenshot(any(), any())).thenReturn(mockResponse);
+      ScreenshotOptions options = new ScreenshotOptions();
+      options.setSync(true);
+
+      // The CLI response is in the format { data: { snapshot-name: 'some_Test', ... and so on } }
+      // We need to extract and use the response from the `data` key
+      JSONObject res = percy.screenshot("Test", options);
+      assertEquals(res.getString("snapshot-name"), "Test");
+    }
+}

--- a/src/test/java/io/percy/appium/AppPercyTest.java
+++ b/src/test/java/io/percy/appium/AppPercyTest.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import io.appium.java_client.android.AndroidDriver;
@@ -18,7 +19,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)
@@ -26,7 +30,7 @@ public class AppPercyTest{
     @Mock
     AndroidDriver<AndroidElement> androidDriver;
     private static AppPercy percy;
-    GenericProvider genericProvider;
+    private static GenericProvider genericProvider;
     private DesiredCapabilities capabilities;
 
     @Before
@@ -39,30 +43,35 @@ public class AppPercyTest{
         capabilities.setCapability("app", "APP_URL");
         capabilities.setCapability("device", "DEVICE_NAME");
         capabilities.setCapability("os_version", "9.0");
+        capabilities.setCapability("percy.enabled", "true");
+        capabilities.setCapability("percy.enabled", "true");
         genericProvider = mock(GenericProvider.class);
     }
 
     @Test
-    public void takeScreenshotWithoutOptions() throws Exception {
+    public void takeScreenshotWithoutPercyEnabled() throws Exception {
       when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
       when(androidDriver.getCapabilities()).thenReturn(capabilities);
-
+      
       try {
-          lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));
+        lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));
       } catch (MalformedURLException e) {
-          throw new RuntimeException(e);
+        throw new RuntimeException(e);
       }
 
       percy = spy(new AppPercy(androidDriver));
       percy.setGenericProvider(genericProvider);
     
-      when(genericProvider.screenshot(any(), any())).thenReturn(null);
       JSONObject res = percy.screenshot("Test");
       assertEquals(res, null);
+      verify(genericProvider, never()).screenshot(eq("Test"), eq(null));
     }
 
     @Test
-    public void takeScreenshotWithSyncOption() throws Exception{
+    public void takeScreenshotWithoutOptions() throws Exception {
+        // Percy Options to Enable Percy
+        capabilities.setCapability("percy.enabled", "true");
+
       when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
       when(androidDriver.getCapabilities()).thenReturn(capabilities);
 
@@ -72,8 +81,33 @@ public class AppPercyTest{
           throw new RuntimeException(e);
       }
 
+      ArgumentCaptor<ScreenshotOptions> captureOptions = ArgumentCaptor.forClass(ScreenshotOptions.class);
       percy = spy(new AppPercy(androidDriver));
       percy.setGenericProvider(genericProvider);
+      percy.setPercyEnabled();
+      when(genericProvider.screenshot(any(), any())).thenReturn(null);
+      JSONObject res = percy.screenshot("Test");
+      assertEquals(res, null);
+      verify(genericProvider).screenshot(eq("Test"), captureOptions.capture());
+      assertNotNull(captureOptions.getValue());
+      assertTrue(captureOptions.getValue() instanceof ScreenshotOptions);
+    }
+
+    @Test
+    public void takeScreenshotWithSyncOption() throws Exception{
+
+      when(androidDriver.getSessionId()).thenReturn(new SessionId("123"));
+      when(androidDriver.getCapabilities()).thenReturn(capabilities);
+      
+      try {
+        lenient(). when(androidDriver.getRemoteAddress()).thenReturn(new URL("https://hub.browserstack.com/wd/hub"));
+      } catch (MalformedURLException e) {
+        throw new RuntimeException(e);
+      }
+      
+      percy = spy(new AppPercy(androidDriver));
+      percy.setGenericProvider(genericProvider);
+      percy.setPercyEnabled();
       JSONObject mockResponse = new JSONObject()
       .put("data", new JSONObject().put("snapshot-name", "Test"));
       when(genericProvider.screenshot(any(), any())).thenReturn(mockResponse);
@@ -83,7 +117,6 @@ public class AppPercyTest{
       // The CLI response is in the format { data: { snapshot-name: 'some_Test', ... and so on } }
       // We need to extract and use the response from the `data` key
       JSONObject res = percy.screenshot("Test", options);
-      System.out.println(" GOJO " + res);
       assertEquals(res.getString("snapshot-name"), "Test");
     }
 }


### PR DESCRIPTION
Issue - 
`respose.getJSONObject('data')`  was used at 2 places therefore returning data key not present during 2nd time.

Changes -
- removed getJSONObject from appAutomate.java and put that it in AppPercy.java
- Added test for AppPercyTest.java