### PR TITLE
Fix orientation change bug 

### DIFF
--- a/src/main/java/io/percy/appium/lib/Utils.java
+++ b/src/main/java/io/percy/appium/lib/Utils.java
@@ -12,10 +12,10 @@ public class Utils {
       if (matcher.find()) {
         return Integer.parseInt(matcher.group(1));
       }
-      return null; // Return -1 if no match found
+      return null; // Return null if no match found
     } catch (Exception ex) {
       AppPercy.log(ex.toString(), "debug");
-      return null;
+      return null; // Return null if any error
     }
   }
 
@@ -27,14 +27,12 @@ public class Utils {
       if (matcher.find()) {
         int bottomCoordinate = Integer.parseInt(matcher.group(1));
         int topCoordinate = Integer.parseInt(matcher.group(2));
-        // int topCoordinate = extractTopCoordinate(input); // Extracting top coordinate
-        // from input
-        return topCoordinate - bottomCoordinate; // Calc
+        return topCoordinate - bottomCoordinate;
       }
-      return null; // Return -1 if no match found
+      return null; // Return null if no match found
     } catch (Exception ex) {
       AppPercy.log(ex.toString(), "debug");
-      return null;
+      return null; // Return null if any error
     }
   }
 }

--- a/src/main/java/io/percy/appium/lib/Utils.java
+++ b/src/main/java/io/percy/appium/lib/Utils.java
@@ -1,0 +1,40 @@
+package io.percy.appium.lib;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import io.percy.appium.AppPercy;
+
+public class Utils {
+  public static Integer extractStatusBarHeight(String input) {
+    try {
+      Pattern pattern = Pattern.compile("ITYPE_STATUS_BAR frame=\\[\\d+,\\d+\\]\\[\\d+,([\\d]+)\\]");
+      Matcher matcher = pattern.matcher(input);
+      if (matcher.find()) {
+        return Integer.parseInt(matcher.group(1));
+      }
+      return null; // Return -1 if no match found
+    } catch (Exception ex) {
+      AppPercy.log(ex.toString(), "debug");
+      return null;
+    }
+  }
+
+  public static Integer extractNavigationBarHeight(String input) {
+    try {
+      Pattern pattern = Pattern.compile("ITYPE_NAVIGATION_BAR frame=\\[\\d+,([\\d]+)\\]\\[\\d+,([\\d]+)\\]");
+      Matcher matcher = pattern.matcher(input);
+
+      if (matcher.find()) {
+        int bottomCoordinate = Integer.parseInt(matcher.group(1));
+        int topCoordinate = Integer.parseInt(matcher.group(2));
+        // int topCoordinate = extractTopCoordinate(input); // Extracting top coordinate
+        // from input
+        return topCoordinate - bottomCoordinate; // Calc
+      }
+      return null; // Return -1 if no match found
+    } catch (Exception ex) {
+      AppPercy.log(ex.toString(), "debug");
+      return null;
+    }
+  }
+}

--- a/src/main/java/io/percy/appium/providers/GenericProvider.java
+++ b/src/main/java/io/percy/appium/providers/GenericProvider.java
@@ -115,29 +115,28 @@ public class GenericProvider {
             String platformVersion, String deviceName) throws Exception {
         this.metadata = MetadataHelper.resolve(driver, deviceName, options.getStatusBarHeight(),
                 options.getNavBarHeight(), options.getOrientation(), platformVersion);
-        JSONObject tag = getTag();
         List<Tile> tiles = captureTiles(options);
+        // Get Tag After captureTile. This is done if orientation is auto.
+        // Orientation get overwrited in metadata.orientation() function.
+        JSONObject tag = getTag();
         JSONArray ignoreRegions = findRegions(
-            options.getIgnoreRegionXpaths(),
-            options.getIgnoreRegionAccessibilityIds(),
-            options.getIgnoreRegionAppiumElements(),
-            options.getCustomIgnoreRegions()
-        );
+                options.getIgnoreRegionXpaths(),
+                options.getIgnoreRegionAccessibilityIds(),
+                options.getIgnoreRegionAppiumElements(),
+                options.getCustomIgnoreRegions());
         JSONArray considerRegions = findRegions(
-            options.getConsiderRegionXpaths(),
-            options.getConsiderRegionAccessibilityIds(),
-            options.getConsiderRegionAppiumElements(),
-            options.getCustomConsiderRegions()
-        );
+                options.getConsiderRegionXpaths(),
+                options.getConsiderRegionAccessibilityIds(),
+                options.getConsiderRegionAppiumElements(),
+                options.getCustomConsiderRegions());
         return cliWrapper.postScreenshot(
-            name,
-            tag,
-            tiles,
-            debugUrl,
-            getObjectForArray("ignoreElementsData", ignoreRegions),
-            getObjectForArray("considerElementsData", considerRegions),
-            options.getSync()
-        );
+                name,
+                tag,
+                tiles,
+                debugUrl,
+                getObjectForArray("ignoreElementsData", ignoreRegions),
+                getObjectForArray("considerElementsData", considerRegions),
+                options.getSync());
     }
 
     public void setMetadata(Metadata metadata) {
@@ -153,11 +152,10 @@ public class GenericProvider {
     }
 
     public JSONArray findRegions(
-        List<String> xpaths,
-        List<String> accessibilityIds,
-        List<WebElement> elements,
-        List<Region> locations
-    ) {
+            List<String> xpaths,
+            List<String> accessibilityIds,
+            List<WebElement> elements,
+            List<Region> locations) {
         JSONArray elementsArray = new JSONArray();
         getRegionsByXpath(elementsArray, xpaths);
         getRegionsByIds(elementsArray, accessibilityIds);

--- a/src/test/java/io/percy/appium/lib/UtilsTest.java
+++ b/src/test/java/io/percy/appium/lib/UtilsTest.java
@@ -1,0 +1,49 @@
+package io.percy.appium.lib;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class UtilsTest {
+  @Test
+  public void testExtractStatusBarHeighWhenPatternIsPresent() {
+    String input = "InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true\n" +
+        "InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,2358][1080,2400] visible=true";
+
+    int expectedStatBarHeight = 74;
+    int actualStatBarHeight = Utils.extractStatusBarHeight(input);
+
+    assertEquals(expectedStatBarHeight, actualStatBarHeight);
+  }
+
+  @Test
+  public void testExtractNavigationBarHeightWhenPatternIsPresent() {
+    String input = "InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true\n" +
+        "InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,2358][1080,2400] visible=true";
+
+    int expectedNavBarHeight = 42;
+    int actualNavBarHeight = Utils.extractNavigationBarHeight(input);
+
+    assertEquals(expectedNavBarHeight, actualNavBarHeight);
+  }
+
+  @Test
+  public void testExtractStatusBarHeighWhenPatternIsNotPresent() {
+    String input = "RANDOM frame=[0,0][2400,74] visible=true\n" +
+        "RANDOM frame=[0,2358][1080,2400] visible=true";
+
+    Integer actualStatBarHeight = Utils.extractStatusBarHeight(input);
+
+    assertEquals(null, actualStatBarHeight);
+  }
+
+  @Test
+  public void testExtractNavigationBarHeightWhenPatternIsNotPresent() {
+    String input = "RANDOM [0,0][2400,74] visible=true\n" +
+        "RANDOM [0,2358][1080,2400] visible=true";
+
+    Integer actualNavBarHeight = Utils.extractNavigationBarHeight(input);
+
+    assertEquals(null, actualNavBarHeight);
+  }
+}

--- a/src/test/java/io/percy/appium/metadata/AndroidMetadataTest.java
+++ b/src/test/java/io/percy/appium/metadata/AndroidMetadataTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -74,18 +75,70 @@ public class AndroidMetadataTest {
     }
 
     @Test
+    public void testStatBarHeightWhenValueGiven() {
+        metadata = new AndroidMetadata(androidDriver, "Samsung Galaxy s22", 100, 200, "auto", null);
+        Assert.assertEquals(metadata.statBarHeight().intValue(), 100);
+    }
+
+    @Test
+    public void testStatBarHeightForAuto() {
+        metadata = new AndroidMetadata(androidDriver, "Samsung Galaxy s22", null, null, "auto", null);
+        JSONObject arguments = new JSONObject();
+        arguments.put("action", "adbShell");
+        JSONObject command = new JSONObject();
+        command.put("command", "dumpsys window displays");
+        arguments.put("arguments", command);
+
+        String response = "InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true\n" +
+                "InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,2358][1080,2400] visible=true";
+
+        when(androidDriver.executeScript(String.format("browserstack_executor: %s", arguments.toString())))
+                .thenReturn(response);
+
+        Integer expectedStatBarHeight = 74;
+        Integer actualStatBarHeight = metadata.statBarHeight();
+        Assert.assertEquals(expectedStatBarHeight, actualStatBarHeight);
+    }
+
+    @Test
     public void testNavBarHeight() {
         Assert.assertEquals(metadata.navBarHeight().intValue(), 2160 - (height + top));
     }
 
     @Test
-    public void testDeviceName(){
+    public void testNavBarHeightWhenValueGiven() {
+        metadata = new AndroidMetadata(androidDriver, "Samsung Galaxy s22", 100, 200, "auto", null);
+        Assert.assertEquals(metadata.navBarHeight().intValue(), 200);
+    }
+
+    @Test
+    public void testNavBarHeightForAuto() {
+        metadata = new AndroidMetadata(androidDriver, "Samsung Galaxy s22", null, null, "auto", null);
+        JSONObject arguments = new JSONObject();
+        arguments.put("action", "adbShell");
+        JSONObject command = new JSONObject();
+        command.put("command", "dumpsys window displays");
+        arguments.put("arguments", command);
+
+        String response = "InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true\n" +
+                "InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,2358][1080,2400] visible=true";
+
+        when(androidDriver.executeScript(String.format("browserstack_executor: %s", arguments.toString())))
+                .thenReturn(response);
+
+        Integer expectedStatBarHeight = 42;
+        Integer actualStatBarHeight = metadata.navBarHeight();
+        Assert.assertEquals(expectedStatBarHeight, actualStatBarHeight);
+    }
+
+    @Test
+    public void testDeviceName() {
         when(capabilities.getCapability("device")).thenReturn("Samsung Galaxy s22");
         Assert.assertEquals(metadata.deviceName(), "Samsung Galaxy s22");
     }
 
     @Test
-    public void testDeviceNameFromDesired(){
+    public void testDeviceNameFromDesired() {
         Map desired = new HashMap<>();
         desired.put("deviceName", "Samsung Galaxy s22");
         when(capabilities.getCapability("desired")).thenReturn(desired);
@@ -93,13 +146,13 @@ public class AndroidMetadataTest {
     }
 
     @Test
-    public void testOsName(){
+    public void testOsName() {
         when(capabilities.getCapability("platformName")).thenReturn("Android");
         Assert.assertEquals(metadata.osName(), "Android");
     }
 
     @Test
-    public void testPlatformVersion(){
+    public void testPlatformVersion() {
         when(capabilities.getCapability("platformVersion")).thenReturn("12");
         Assert.assertEquals(metadata.platformVersion(), "12");
     }
@@ -142,7 +195,7 @@ public class AndroidMetadataTest {
     }
 
     @Test
-    public void testOrientatioWithNullParamAndCaps(){
+    public void testOrientatioWithNullParamAndCaps() {
         when(androidDriver.getCapabilities().getCapability("orientation")).thenReturn(ScreenOrientation.LANDSCAPE);
         Assert.assertEquals(metadata.orientation(), "landscape");
     }


### PR DESCRIPTION
Fix orientation change bug that causes stat bar and nav bar height to wrong values.
Using ADB  command  `dumpsys window displays` to get sysdump of display.

Output is String and the below are the values that is conatained in that string.
```
InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true
InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,1038][2400,1080] visible=true
InsetsSource type=ITYPE_LEFT_GESTURES frame=[0,0][78,1080] visible=true
InsetsSource type=ITYPE_RIGHT_GESTURES frame=[2204,0][2400,1080] visible=true
```

StatBar is `ITYPE_STATUS_BAR` -> 74.
NavBar is `ITYPE_NAVIGATION_BAR` -> 1080 - 1038 = 42.