### PR TITLE
Papp 422 | Fix v8 upgrade issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
         <groupId>io.appium</groupId>
         <artifactId>java-client</artifactId>
-        <version>8.1.0</version>
+        <version>8.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/src/main/java/io/percy/appium/PercyOnAutomate.java
+++ b/src/main/java/io/percy/appium/PercyOnAutomate.java
@@ -1,10 +1,10 @@
 package io.percy.appium;
 
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.MobileElement;
 import io.percy.appium.lib.CliWrapper;
 import io.percy.appium.lib.PercyOptions;
 import io.percy.appium.metadata.DriverMetadata;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.util.Map;
 
@@ -86,14 +86,14 @@ public class PercyOnAutomate extends IPercy {
 
                 if (options.containsKey(ignoreElementKey)) {
                     List<String> ignoreElementIds =
-                            getElementIdFromElement((List<MobileElement>) options.get(ignoreElementKey));
+                            getElementIdFromElement((List<RemoteWebElement>) options.get(ignoreElementKey));
                     options.remove(ignoreElementKey);
                     options.put("ignore_region_elements", ignoreElementIds);
                 }
 
                 if (options.containsKey(considerElementKey)) {
                     List<String> considerElementIds =
-                            getElementIdFromElement((List<MobileElement>) options.get(considerElementKey));
+                            getElementIdFromElement((List<RemoteWebElement>) options.get(considerElementKey));
                     options.remove(considerElementKey);
                     options.put("consider_region_elements", considerElementIds);
                 }
@@ -121,9 +121,9 @@ public class PercyOnAutomate extends IPercy {
         }
     }
 
-    private List<String> getElementIdFromElement(List<MobileElement> elements) {
+    private List<String> getElementIdFromElement(List<RemoteWebElement> elements) {
         List<String> ignoredElementsArray = new ArrayList<>();
-        for (MobileElement element : elements) {
+        for (RemoteWebElement element : elements) {
             String elementId = element.getId();
             ignoredElementsArray.add(elementId);
         }

--- a/src/main/java/io/percy/appium/metadata/AndroidMetadata.java
+++ b/src/main/java/io/percy/appium/metadata/AndroidMetadata.java
@@ -96,4 +96,28 @@ public class AndroidMetadata extends Metadata {
         return (String) Cache.CACHE_MAP.get("getDisplaySysDump_" + sessionId);
     }
 
+
+    public String orientation() {
+      if (orientation != null) {
+          if (orientation.toLowerCase().equals("portrait") || orientation.toLowerCase().equals("landscape")) {
+              return orientation.toLowerCase();
+          } else if (orientation.toLowerCase().equals("auto")) {
+              try {
+                  return driver.getOrientation().toString().toLowerCase();
+              } catch (java.lang.NoSuchMethodError e) {
+                  return "portrait";
+              }
+          } else {
+              return "portrait";
+          }
+      } else {
+          Object orientationCapability = driver.getCapabilities().getCapability("orientation");
+          if (orientationCapability != null) {
+              return orientationCapability.toString().toLowerCase();
+          } else {
+              return "portrait";
+          }
+      }
+  }
+
 }

--- a/src/main/java/io/percy/appium/metadata/IosMetadata.java
+++ b/src/main/java/io/percy/appium/metadata/IosMetadata.java
@@ -9,11 +9,13 @@ import io.percy.appium.lib.Cache;
 public class IosMetadata extends Metadata {
     private IOSDriver driver;
     private String sessionId;
+    private String orientation;
 
     public IosMetadata(AppiumDriver driver, String deviceName, Integer statusBar, Integer navBar, String orientation,
             String platformVersion) {
         super(driver, deviceName, statusBar, navBar, orientation, platformVersion);
         this.driver = (IOSDriver) driver;
+        this.orientation = orientation;
         this.sessionId = driver.getSessionId().toString();
     }
 
@@ -81,5 +83,29 @@ public class IosMetadata extends Metadata {
     public Integer scaleFactor() {
         return Integer.valueOf(getSession().get("pixelRatio").toString());
     }
+
+
+    public String orientation() {
+      if (orientation != null) {
+          if (orientation.toLowerCase().equals("portrait") || orientation.toLowerCase().equals("landscape")) {
+              return orientation.toLowerCase();
+          } else if (orientation.toLowerCase().equals("auto")) {
+              try {
+                  return driver.getOrientation().toString().toLowerCase();
+              } catch (java.lang.NoSuchMethodError e) {
+                  return "portrait";
+              }
+          } else {
+              return "portrait";
+          }
+      } else {
+          Object orientationCapability = driver.getCapabilities().getCapability("orientation");
+          if (orientationCapability != null) {
+              return orientationCapability.toString().toLowerCase();
+          } else {
+              return "portrait";
+          }
+      }
+  }
 
 }

--- a/src/main/java/io/percy/appium/metadata/Metadata.java
+++ b/src/main/java/io/percy/appium/metadata/Metadata.java
@@ -47,29 +47,6 @@ public abstract class Metadata {
         return osVersion.toString();
     }
 
-    public String orientation() {
-        if (orientation != null) {
-            if (orientation.toLowerCase().equals("portrait") || orientation.toLowerCase().equals("landscape")) {
-                return orientation.toLowerCase();
-            } else if (orientation.toLowerCase().equals("auto")) {
-                try {
-                    return driver.getOrientation().toString().toLowerCase();
-                } catch (java.lang.NoSuchMethodError e) {
-                    return "portrait";
-                }
-            } else {
-                return "portrait";
-            }
-        } else {
-            Object orientationCapability = driver.getCapabilities().getCapability("orientation");
-            if (orientationCapability != null) {
-                return orientationCapability.toString().toLowerCase();
-            } else {
-                return "portrait";
-            }
-        }
-    }
-
     public String getDeviceName() {
         return deviceName;
     }
@@ -92,6 +69,8 @@ public abstract class Metadata {
     }
 
     public abstract Integer deviceScreenWidth();
+
+    public abstract String orientation();
 
     public abstract String deviceName();
 

--- a/src/main/java/io/percy/appium/providers/AppAutomate.java
+++ b/src/main/java/io/percy/appium/providers/AppAutomate.java
@@ -61,6 +61,7 @@ public class AppAutomate extends GenericProvider {
             }
         } catch (Exception e) {
             AppPercy.log("BrowserStack executer failed");
+            AppPercy.log(e.toString(), "debug");
         }
         return null;
     }
@@ -89,6 +90,7 @@ public class AppAutomate extends GenericProvider {
             }
         } catch (Exception e) {
             AppPercy.log("BrowserStack executer failed");
+            AppPercy.log(e.toString(), "debug");
         }
     }
 
@@ -126,6 +128,7 @@ public class AppAutomate extends GenericProvider {
             JSONObject result = new JSONObject(resultString);
             return result.get("result").toString();
         } catch (Exception e) {
+            AppPercy.log(e.toString(), "debug");
             throw new Exception("Screenshot command failed");
         }
     }

--- a/src/test/java/io/percy/appium/AppPercyTest.java
+++ b/src/test/java/io/percy/appium/AppPercyTest.java
@@ -11,7 +11,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
 
 import org.openqa.selenium.remote.*;
 
@@ -28,7 +27,7 @@ import static org.mockito.Mockito.*;
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class AppPercyTest{
     @Mock
-    AndroidDriver<AndroidElement> androidDriver;
+    AndroidDriver androidDriver;
     private static AppPercy percy;
     private static GenericProvider genericProvider;
     private DesiredCapabilities capabilities;

--- a/src/test/java/io/percy/appium/PercyOnAutomateTest.java
+++ b/src/test/java/io/percy/appium/PercyOnAutomateTest.java
@@ -1,6 +1,5 @@
 package io.percy.appium;
 
-import io.appium.java_client.MobileElement;
 import io.percy.appium.lib.CliWrapper;
 
 import org.json.JSONObject;
@@ -66,7 +65,7 @@ public class PercyOnAutomateTest {
         percy.setCliWrapper(cliMock);
         when(cliMock.healthcheck()).thenReturn(true);
         Map<String, Object> options = new HashMap<>();
-        MobileElement mockedElement = mock(MobileElement.class);
+        RemoteWebElement mockedElement = mock(RemoteWebElement.class);
         when(mockedElement.getId()).thenReturn("1234");
         options.put("ignore_region_appium_elements", Arrays.asList(mockedElement));
         percy.screenshot("Test", options);

--- a/src/test/java/io/percy/appium/lib/ScreenshotOptionsTest.java
+++ b/src/test/java/io/percy/appium/lib/ScreenshotOptionsTest.java
@@ -9,8 +9,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebElement;
-
-import io.appium.java_client.MobileElement;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class ScreenshotOptionsTest {
@@ -20,11 +19,11 @@ public class ScreenshotOptionsTest {
 
         // Create a list of MobileElements
         List<Object> mobileElements = new ArrayList<>();
-        mobileElements.add(new MobileElement() {});
+        mobileElements.add(new RemoteWebElement() {});
         mobileElements.add(new Object());
         mobileElements.add(new Object());
-        mobileElements.add(new MobileElement() {});
-        mobileElements.add(new MobileElement() {});
+        mobileElements.add(new RemoteWebElement() {});
+        mobileElements.add(new RemoteWebElement() {});
 
         // Call the function to cast them to WebElements
         List<WebElement> webElements = casting.castMobileElementsToWebElements(mobileElements);

--- a/src/test/java/io/percy/appium/providers/GenericProviderTest.java
+++ b/src/test/java/io/percy/appium/providers/GenericProviderTest.java
@@ -1,6 +1,5 @@
 package io.percy.appium.providers;
 
-import io.appium.java_client.MobileElement;
 import io.appium.java_client.android.AndroidDriver;
 import io.percy.appium.lib.Cache;
 import io.percy.appium.lib.Region;


### PR DESCRIPTION
v7 -> v8 Migration
- getOrientation move to android/ios driver fn
- MobileElement class is removed use RemoteWebElemet instead
- upgrading to v8.6.0 as older version had some bugs and 8.6.0 is latest in v8 series