### PR TITLE
Fixing incorrect value of status bar and nav bar height for Android version 14

### DIFF
--- a/src/main/java/io/percy/appium/lib/Utils.java
+++ b/src/main/java/io/percy/appium/lib/Utils.java
@@ -12,6 +12,14 @@ public class Utils {
       if (matcher.find()) {
         return Integer.parseInt(matcher.group(1));
       }
+
+      // For android version 14 update
+      Pattern secondPattern = Pattern.compile("statusBars frame=\\[\\d+,\\d+\\]\\[\\d+,([\\d]+)\\]");
+      Matcher secondMatcher = secondPattern.matcher(input);
+      if (secondMatcher.find()) {
+        return Integer.parseInt(secondMatcher.group(1));
+      }
+
       return null; // Return null if no match found
     } catch (Exception ex) {
       AppPercy.log(ex.toString(), "debug");
@@ -27,6 +35,16 @@ public class Utils {
       if (matcher.find()) {
         int bottomCoordinate = Integer.parseInt(matcher.group(1));
         int topCoordinate = Integer.parseInt(matcher.group(2));
+        return topCoordinate - bottomCoordinate;
+      }
+
+      // For android version 14 update
+      Pattern secondPattern = Pattern.compile("navigationBars frame=\\[\\d+,([\\d]+)\\]\\[\\d+,([\\d]+)\\]");
+      Matcher secondMatcher = secondPattern.matcher(input);
+
+      if (secondMatcher.find()) {
+        int bottomCoordinate = Integer.parseInt(secondMatcher.group(1));
+        int topCoordinate = Integer.parseInt(secondMatcher.group(2));
         return topCoordinate - bottomCoordinate;
       }
       return null; // Return null if no match found

--- a/src/test/java/io/percy/appium/lib/UtilsTest.java
+++ b/src/test/java/io/percy/appium/lib/UtilsTest.java
@@ -17,9 +17,31 @@ public class UtilsTest {
   }
 
   @Test
+  public void testExtractStatusBarHeighWhenNewPatternIsPresent() {
+    String input = "InsetsSource type=statusBars frame=[0,0][2400,74] visible=true\n" +
+        "InsetsSource type=navigationBars frame=[0,2358][1080,2400] visible=true";
+
+    int expectedStatBarHeight = 74;
+    int actualStatBarHeight = Utils.extractStatusBarHeight(input);
+
+    assertEquals(expectedStatBarHeight, actualStatBarHeight);
+  }
+
+  @Test
   public void testExtractNavigationBarHeightWhenPatternIsPresent() {
     String input = "InsetsSource type=ITYPE_STATUS_BAR frame=[0,0][2400,74] visible=true\n" +
         "InsetsSource type=ITYPE_NAVIGATION_BAR frame=[0,2358][1080,2400] visible=true";
+
+    int expectedNavBarHeight = 42;
+    int actualNavBarHeight = Utils.extractNavigationBarHeight(input);
+
+    assertEquals(expectedNavBarHeight, actualNavBarHeight);
+  }
+
+  @Test
+  public void testExtractNavigationBarHeightWhenNewPatternIsPresent() {
+    String input = "InsetsSource type=statusBars frame=[0,0][2400,74] visible=true\n" +
+        "InsetsSource type=navigationBars frame=[0,2358][1080,2400] visible=true";
 
     int expectedNavBarHeight = 42;
     int actualNavBarHeight = Utils.extractNavigationBarHeight(input);


### PR DESCRIPTION
adding support for android version 14
There is a change in adb command `dumpsys window displays` in Android 14.
Which was causing stat bar and nav bar to be 0