### PR TITLE
Per 9999 auto publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         java-version: 8
         distribution: 'adopt'
-        server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: MAVEN_USERNAME # env variable for username in deploy
         server-password: MAVEN_PASSWORD # env variable for token in deploy
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-appium-app</artifactId>
-  <version>2.2.2-alpha.1</version>
+  <version>2.2.2-alpha.2</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -187,6 +187,7 @@
           <extensions>true</extensions>
           <configuration>
             <publishingServerId>central</publishingServerId>
+            <autoPublish>true</autoPublish>
           </configuration>
         </plugin>
       <plugin>

--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -4,7 +4,7 @@ import io.appium.java_client.AppiumDriver;
 
 public class Environment {
     private AppiumDriver driver;
-    public static final String SDK_VERSION = "2.2.1-alpha.1";
+    public static final String SDK_VERSION = "2.2.1-alpha.2";
     private static final String SDK_NAME = "percy-appium-app";
     private static String percyBuildID;
     private static String percyBuildUrl;


### PR DESCRIPTION
This pull request contains minor updates to the build and release configuration, as well as version bumps for both the SDK and the Maven artifact. The changes ensure the project is ready for the next alpha release and improve the publishing process.

Version updates:

* Bumped the Maven artifact version in `pom.xml` from `2.2.2-alpha.1` to `2.2.2-alpha.2`.
* Updated the `SDK_VERSION` constant in `Environment.java` from `2.2.1-alpha.1` to `2.2.1-alpha.2`.

Build and release process improvements:

* Changed the Maven publishing server ID from `ossrh` to `central` in the GitHub Actions workflow (`.github/workflows/release.yml`) and in the Maven plugin configuration in `pom.xml` to align with the repository configuration. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L17-R17) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R190)
* Enabled automatic publishing by setting `<autoPublish>true</autoPublish>` in the Maven plugin configuration in `pom.xml`.