### PR TITLE
Add Cucumber step definitions for Percy visual testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.14</version>
     </dependency>
+    <!-- Cucumber (optional - for BDD step definitions) -->
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <version>7.15.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -14,7 +14,13 @@ public class Environment {
         this.driver = driver;
     }
 
+    private String clientInfoOverride;
+    private String environmentInfoOverride;
+
     public String getClientInfo(Boolean flag) {
+        if (clientInfoOverride != null) {
+            return clientInfoOverride;
+        }
         if (flag) {
             return SDK_NAME + "-java" + "/" + SDK_VERSION;
         }
@@ -22,11 +28,26 @@ public class Environment {
     }
 
     public String getEnvironmentInfo() {
+        if (environmentInfoOverride != null) {
+            return environmentInfoOverride;
+        }
         String[] splitDriverName = driver.getClass().getName().split("\\.");
         String driverName = splitDriverName[splitDriverName.length - 1];
 
         // We don't know this type of driver. Report its classname as environment info.
         return String.format("appium-java; %s", driverName);
+    }
+
+    public void setClientInfo(String clientInfo) {
+        this.clientInfoOverride = clientInfo;
+    }
+
+    public void setEnvironmentInfo(String environmentInfo) {
+        this.environmentInfoOverride = environmentInfo;
+    }
+
+    public static String getSdkVersion() {
+        return SDK_VERSION;
     }
 
     public static String getPercyBuildID() {

--- a/src/main/java/io/percy/appium/Percy.java
+++ b/src/main/java/io/percy/appium/Percy.java
@@ -25,6 +25,22 @@ public class Percy {
         }
     }
 
+    /**
+     * Override the client info reported to Percy.
+     * Used by framework wrappers (e.g., Cucumber) to identify themselves.
+     */
+    public void setClientInfo(String clientInfo, String environmentInfo) {
+        cliWrapper.getEnvironment().setClientInfo(clientInfo);
+        cliWrapper.getEnvironment().setEnvironmentInfo(environmentInfo);
+    }
+
+    /**
+     * Get the SDK version string.
+     */
+    public static String getSdkVersion() {
+        return Environment.getSdkVersion();
+    }
+
     public JSONObject screenshot(String name) {
         try {
             return percy.screenshot(name);

--- a/src/main/java/io/percy/appium/cucumber/PercySteps.java
+++ b/src/main/java/io/percy/appium/cucumber/PercySteps.java
@@ -4,9 +4,11 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
 import io.cucumber.java.en.Then;
 import io.percy.appium.Percy;
+import io.percy.appium.lib.Region;
 import io.percy.appium.lib.ScreenshotOptions;
 
 import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.WebElement;
 
 import java.util.*;
 
@@ -167,6 +169,54 @@ public class PercySteps {
         screenshotOptions.setLabels(labels);
     }
 
+    @Given("I set th test case execution ID {string}")
+    public void iSetThTestCaseExecutionId(String id) {
+        ensureOptions();
+        screenshotOptions.setThTestCaseExecutionId(id);
+    }
+
+    @Given("I set sync to {string}")
+    public void iSetSync(String sync) {
+        ensureOptions();
+        screenshotOptions.setSync(Boolean.parseBoolean(sync));
+    }
+
+    @Given("I set scrollable XPath {string}")
+    public void iSetScrollableXpath(String xpath) {
+        ensureOptions();
+        screenshotOptions.setScrollableXpath(xpath);
+    }
+
+    @Given("I set scrollable ID {string}")
+    public void iSetScrollableId(String id) {
+        ensureOptions();
+        screenshotOptions.setScrollableId(id);
+    }
+
+    @Given("I set top scrollview offset {int}")
+    public void iSetTopScrollviewOffset(int offset) {
+        ensureOptions();
+        screenshotOptions.setTopScrollviewOffset(offset);
+    }
+
+    @Given("I set bottom scrollview offset {int}")
+    public void iSetBottomScrollviewOffset(int offset) {
+        ensureOptions();
+        screenshotOptions.setBottomScrollviewOffset(offset);
+    }
+
+    @Given("I set scroll speed {int}")
+    public void iSetScrollSpeed(int speed) {
+        ensureOptions();
+        screenshotOptions.setScrollSpeed(speed);
+    }
+
+    @Given("I set android scroll area percentage {int}")
+    public void iSetAndroidScrollAreaPercentage(int percentage) {
+        ensureOptions();
+        screenshotOptions.setAndroidScrollAreaPercentage(percentage);
+    }
+
     // ------------------------------------------------------------------
     // Ignore/Consider regions
     // ------------------------------------------------------------------
@@ -201,6 +251,40 @@ public class PercySteps {
         List<String> ids = new ArrayList<>(screenshotOptions.getConsiderRegionAccessibilityIds());
         ids.add(accessibilityId);
         screenshotOptions.setConsiderRegionAccessibilityIds(ids);
+    }
+
+    @Given("I add custom ignore region {int}, {int}, {int}, {int}")
+    public void iAddCustomIgnoreRegion(int top, int bottom, int left, int right) {
+        ensureOptions();
+        List<Region> regions = new ArrayList<>(screenshotOptions.getCustomIgnoreRegions());
+        regions.add(new Region(top, bottom, left, right));
+        screenshotOptions.setCustomIgnoreRegions(regions);
+    }
+
+    @Given("I add custom consider region {int}, {int}, {int}, {int}")
+    public void iAddCustomConsiderRegion(int top, int bottom, int left, int right) {
+        ensureOptions();
+        List<Region> regions = new ArrayList<>(screenshotOptions.getCustomConsiderRegions());
+        regions.add(new Region(top, bottom, left, right));
+        screenshotOptions.setCustomConsiderRegions(regions);
+    }
+
+    @Given("I add ignore region Appium element {string}")
+    public void iAddIgnoreRegionAppiumElement(String locator) {
+        ensureOptions();
+        WebElement element = driver.findElement(org.openqa.selenium.By.xpath(locator));
+        List<Object> elements = new ArrayList<>(screenshotOptions.getIgnoreRegionAppiumElements());
+        elements.add(element);
+        screenshotOptions.setIgnoreRegionAppiumElements(elements);
+    }
+
+    @Given("I add consider region Appium element {string}")
+    public void iAddConsiderRegionAppiumElement(String locator) {
+        ensureOptions();
+        WebElement element = driver.findElement(org.openqa.selenium.By.xpath(locator));
+        List<Object> elements = new ArrayList<>(screenshotOptions.getConsiderRegionAppiumElements());
+        elements.add(element);
+        screenshotOptions.setConsiderRegionAppiumElements(elements);
     }
 
     @Given("I clear Percy options")

--- a/src/main/java/io/percy/appium/cucumber/PercySteps.java
+++ b/src/main/java/io/percy/appium/cucumber/PercySteps.java
@@ -10,7 +10,8 @@ import io.percy.appium.lib.ScreenshotOptions;
 import io.appium.java_client.AppiumDriver;
 import org.openqa.selenium.WebElement;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Cucumber step definitions for Percy visual testing with Appium.

--- a/src/main/java/io/percy/appium/cucumber/PercySteps.java
+++ b/src/main/java/io/percy/appium/cucumber/PercySteps.java
@@ -1,0 +1,260 @@
+package io.percy.appium.cucumber;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
+import io.percy.appium.Percy;
+import io.percy.appium.lib.ScreenshotOptions;
+
+import io.appium.java_client.AppiumDriver;
+
+import java.util.*;
+
+/**
+ * Cucumber step definitions for Percy visual testing with Appium.
+ *
+ * <p>Provides Gherkin steps to capture Percy screenshots from Cucumber
+ * feature files using Appium drivers (Android/iOS).</p>
+ *
+ * <p>Usage in feature files:</p>
+ * <pre>
+ * Feature: Mobile Visual Testing
+ *   Scenario: Homepage screenshot
+ *     Given I have a Percy instance
+ *     When I take a Percy screenshot named "Homepage"
+ *
+ *   Scenario: Full page screenshot
+ *     Given I have a Percy instance
+ *     When I take a Percy screenshot named "Full Page" with full page
+ *
+ *   Scenario: Ignore region
+ *     Given I have a Percy instance
+ *     And I add ignore region XPath "//android.widget.Button[@text='AD']"
+ *     When I take a Percy screenshot named "No Ads" with options
+ * </pre>
+ *
+ * <p>Setup in step definition glue:</p>
+ * <pre>
+ * public class Hooks {
+ *     {@literal @}Before
+ *     public void setUp() {
+ *         AppiumDriver driver = new AndroidDriver(url, caps);
+ *         PercySteps.setDriver(driver);
+ *     }
+ *
+ *     {@literal @}After
+ *     public void tearDown() {
+ *         PercySteps.reset();
+ *     }
+ * }
+ * </pre>
+ */
+public class PercySteps {
+
+    private static AppiumDriver driver;
+    private static Percy percy;
+    private static ScreenshotOptions screenshotOptions;
+
+    private static final String CUCUMBER_CLIENT_NAME = "percy-cucumber-java-appium";
+
+    /**
+     * Set the AppiumDriver instance for Percy to use.
+     * Call this from your Cucumber hooks before using any Percy steps.
+     *
+     * @param appiumDriver the Appium driver instance
+     */
+    public static void setDriver(AppiumDriver appiumDriver) {
+        driver = appiumDriver;
+        percy = new Percy(driver);
+        screenshotOptions = new ScreenshotOptions();
+
+        // Identify as Cucumber wrapper in Percy build info
+        String sdkVersion = Percy.getSdkVersion();
+        String cucumberVersion = getCucumberVersion();
+        percy.setClientInfo(
+            CUCUMBER_CLIENT_NAME + "/" + sdkVersion,
+            "cucumber-java/" + cucumberVersion + "; appium-java"
+        );
+    }
+
+    /**
+     * Get the current Percy instance.
+     */
+    public static Percy getPercy() {
+        return percy;
+    }
+
+    /**
+     * Reset the Percy instance and clear stored options.
+     * Call this from your Cucumber hooks in teardown.
+     */
+    public static void reset() {
+        percy = null;
+        driver = null;
+        screenshotOptions = null;
+    }
+
+    private static String getCucumberVersion() {
+        try {
+            Package pkg = io.cucumber.java.en.Given.class.getPackage();
+            String version = pkg != null ? pkg.getImplementationVersion() : null;
+            return version != null ? version : "unknown";
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Given steps
+    // ------------------------------------------------------------------
+
+    @Given("I have a Percy instance")
+    public void iHaveAPercyInstance() {
+        if (driver == null) {
+            throw new IllegalStateException(
+                "AppiumDriver not set. Call PercySteps.setDriver(driver) in your @Before hook.");
+        }
+        if (percy == null) {
+            percy = new Percy(driver);
+        }
+    }
+
+    @Given("I set device name {string}")
+    public void iSetDeviceName(String deviceName) {
+        ensureOptions();
+        screenshotOptions.setDeviceName(deviceName);
+    }
+
+    @Given("I set orientation {string}")
+    public void iSetOrientation(String orientation) {
+        ensureOptions();
+        screenshotOptions.setOrientation(orientation);
+    }
+
+    @Given("I set status bar height {int}")
+    public void iSetStatusBarHeight(int height) {
+        ensureOptions();
+        screenshotOptions.setStatusBarHeight(height);
+    }
+
+    @Given("I set nav bar height {int}")
+    public void iSetNavBarHeight(int height) {
+        ensureOptions();
+        screenshotOptions.setNavBarHeight(height);
+    }
+
+    @Given("I set full page to {string}")
+    public void iSetFullPage(String fullPage) {
+        ensureOptions();
+        screenshotOptions.setFullPage(Boolean.parseBoolean(fullPage));
+    }
+
+    @Given("I set screen lengths {int}")
+    public void iSetScreenLengths(int lengths) {
+        ensureOptions();
+        screenshotOptions.setScreenLengths(lengths);
+    }
+
+    @Given("I set test case {string}")
+    public void iSetTestCase(String testCase) {
+        ensureOptions();
+        screenshotOptions.setTestCase(testCase);
+    }
+
+    @Given("I set labels {string}")
+    public void iSetLabels(String labels) {
+        ensureOptions();
+        screenshotOptions.setLabels(labels);
+    }
+
+    // ------------------------------------------------------------------
+    // Ignore/Consider regions
+    // ------------------------------------------------------------------
+
+    @Given("I add ignore region XPath {string}")
+    public void iAddIgnoreRegionXPath(String xpath) {
+        ensureOptions();
+        List<String> xpaths = new ArrayList<>(screenshotOptions.getIgnoreRegionXpaths());
+        xpaths.add(xpath);
+        screenshotOptions.setIgnoreRegionXpaths(xpaths);
+    }
+
+    @Given("I add ignore region accessibility ID {string}")
+    public void iAddIgnoreRegionAccessibilityId(String accessibilityId) {
+        ensureOptions();
+        List<String> ids = new ArrayList<>(screenshotOptions.getIgnoreRegionAccessibilityIds());
+        ids.add(accessibilityId);
+        screenshotOptions.setIgnoreRegionAccessibilityIds(ids);
+    }
+
+    @Given("I add consider region XPath {string}")
+    public void iAddConsiderRegionXPath(String xpath) {
+        ensureOptions();
+        List<String> xpaths = new ArrayList<>(screenshotOptions.getConsiderRegionXpaths());
+        xpaths.add(xpath);
+        screenshotOptions.setConsiderRegionXpaths(xpaths);
+    }
+
+    @Given("I add consider region accessibility ID {string}")
+    public void iAddConsiderRegionAccessibilityId(String accessibilityId) {
+        ensureOptions();
+        List<String> ids = new ArrayList<>(screenshotOptions.getConsiderRegionAccessibilityIds());
+        ids.add(accessibilityId);
+        screenshotOptions.setConsiderRegionAccessibilityIds(ids);
+    }
+
+    @Given("I clear Percy options")
+    public void iClearPercyOptions() {
+        screenshotOptions = new ScreenshotOptions();
+    }
+
+    // ------------------------------------------------------------------
+    // When steps - Screenshot
+    // ------------------------------------------------------------------
+
+    @When("I take a Percy screenshot named {string}")
+    public void iTakeScreenshot(String name) {
+        percy.screenshot(name);
+    }
+
+    @When("I take a Percy screenshot named {string} with full page")
+    public void iTakeScreenshotFullPage(String name) {
+        percy.screenshot(name, true);
+    }
+
+    @When("I take a Percy screenshot named {string} with full screen")
+    public void iTakeScreenshotFullScreen(String name) {
+        ensureOptions();
+        screenshotOptions.setFullScreen(true);
+        percy.screenshot(name, screenshotOptions);
+        screenshotOptions = new ScreenshotOptions();
+    }
+
+    @When("I take a Percy screenshot named {string} with options")
+    public void iTakeScreenshotWithOptions(String name) {
+        ensureOptions();
+        percy.screenshot(name, screenshotOptions);
+        screenshotOptions = new ScreenshotOptions();
+    }
+
+    // ------------------------------------------------------------------
+    // Then steps
+    // ------------------------------------------------------------------
+
+    @Then("Percy should be enabled")
+    public void percyShouldBeEnabled() {
+        if (percy == null) {
+            throw new IllegalStateException("Percy instance not initialized.");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private void ensureOptions() {
+        if (screenshotOptions == null) {
+            screenshotOptions = new ScreenshotOptions();
+        }
+    }
+}

--- a/src/main/java/io/percy/appium/lib/CliWrapper.java
+++ b/src/main/java/io/percy/appium/lib/CliWrapper.java
@@ -32,6 +32,10 @@ public class CliWrapper {
         this.env = new Environment(driver);
     }
 
+    public Environment getEnvironment() {
+        return this.env;
+    }
+
     /**
      * Checks to make sure the local Percy server is running. If not, disable Percy.
      */

--- a/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
+++ b/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
@@ -4,14 +4,18 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import io.appium.java_client.android.AndroidDriver;
+import io.percy.appium.Percy;
+import io.percy.appium.lib.ScreenshotOptions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;
 
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -21,6 +25,7 @@ public class PercyStepsTest {
     @Mock
     AndroidDriver mockDriver;
 
+    private Percy mockPercy;
     private PercySteps steps;
 
     @Before
@@ -36,6 +41,7 @@ public class PercyStepsTest {
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
+        mockPercy = mock(Percy.class);
         steps = new PercySteps();
     }
 
@@ -43,6 +49,25 @@ public class PercyStepsTest {
     public void tearDown() {
         PercySteps.reset();
     }
+
+    private void initWithMockPercy() {
+        PercySteps.setDriver(mockDriver);
+        setPercyField(mockPercy);
+    }
+
+    private void setPercyField(Percy percy) {
+        try {
+            Field field = PercySteps.class.getDeclaredField("percy");
+            field.setAccessible(true);
+            field.set(null, percy);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Lifecycle tests
+    // ------------------------------------------------------------------
 
     @Test
     public void testSetDriverAndGetPercy() {
@@ -70,6 +95,10 @@ public class PercyStepsTest {
         steps.iHaveAPercyInstance();
         assertNotNull(PercySteps.getPercy());
     }
+
+    // ------------------------------------------------------------------
+    // Option setter tests
+    // ------------------------------------------------------------------
 
     @Test
     public void testSetDeviceName() {
@@ -162,6 +191,16 @@ public class PercyStepsTest {
     }
 
     @Test
+    public void testSetThTestCaseExecutionId() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetThTestCaseExecutionId("exec-123");
+    }
+
+    // ------------------------------------------------------------------
+    // Region tests
+    // ------------------------------------------------------------------
+
+    @Test
     public void testAddIgnoreRegionXPath() {
         PercySteps.setDriver(mockDriver);
         steps.iAddIgnoreRegionXPath("//android.widget.Button[@text='AD']");
@@ -204,6 +243,99 @@ public class PercyStepsTest {
         steps.iClearPercyOptions();
     }
 
+    // ------------------------------------------------------------------
+    // Screenshot tests
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testTakeScreenshot() {
+        initWithMockPercy();
+        steps.iTakeScreenshot("Homepage");
+        verify(mockPercy).screenshot("Homepage");
+    }
+
+    @Test
+    public void testTakeScreenshotFullPage() {
+        initWithMockPercy();
+        steps.iTakeScreenshotFullPage("Full Page");
+        verify(mockPercy).screenshot(eq("Full Page"), eq(true));
+    }
+
+    @Test
+    public void testTakeScreenshotFullScreen() {
+        initWithMockPercy();
+        steps.iTakeScreenshotFullScreen("Full Screen");
+        ArgumentCaptor<ScreenshotOptions> captor = ArgumentCaptor.forClass(ScreenshotOptions.class);
+        verify(mockPercy).screenshot(eq("Full Screen"), captor.capture());
+        assertTrue(captor.getValue().getFullScreen());
+    }
+
+    @Test
+    public void testTakeScreenshotWithOptions() {
+        initWithMockPercy();
+        steps.iSetDeviceName("Pixel 6");
+        steps.iSetOrientation("portrait");
+        steps.iAddIgnoreRegionXPath("//ad");
+        steps.iTakeScreenshotWithOptions("With Options");
+        ArgumentCaptor<ScreenshotOptions> captor = ArgumentCaptor.forClass(ScreenshotOptions.class);
+        verify(mockPercy).screenshot(eq("With Options"), captor.capture());
+        ScreenshotOptions opts = captor.getValue();
+        assertEquals("Pixel 6", opts.getDeviceName());
+        assertEquals("portrait", opts.getOrientation());
+        assertEquals(1, opts.getIgnoreRegionXpaths().size());
+        assertEquals("//ad", opts.getIgnoreRegionXpaths().get(0));
+    }
+
+    @Test
+    public void testTakeScreenshotWithOptionsResetsAfterCall() {
+        initWithMockPercy();
+        steps.iSetDeviceName("Pixel 6");
+        steps.iTakeScreenshotWithOptions("First");
+
+        steps.iTakeScreenshotWithOptions("Second");
+        ArgumentCaptor<ScreenshotOptions> captor = ArgumentCaptor.forClass(ScreenshotOptions.class);
+        verify(mockPercy).screenshot(eq("Second"), captor.capture());
+        assertNull(captor.getValue().getDeviceName());
+    }
+
+    @Test
+    public void testTakeScreenshotFullScreenResetsAfterCall() {
+        initWithMockPercy();
+        steps.iSetDeviceName("iPhone 14");
+        steps.iTakeScreenshotFullScreen("FS");
+
+        steps.iTakeScreenshotWithOptions("After FS");
+        ArgumentCaptor<ScreenshotOptions> captor = ArgumentCaptor.forClass(ScreenshotOptions.class);
+        verify(mockPercy).screenshot(eq("After FS"), captor.capture());
+        assertNull(captor.getValue().getDeviceName());
+        assertFalse(captor.getValue().getFullScreen());
+    }
+
+    @Test
+    public void testTakeScreenshotWithIgnoreAndConsiderRegions() {
+        initWithMockPercy();
+        steps.iAddIgnoreRegionXPath("//ad");
+        steps.iAddIgnoreRegionAccessibilityId("banner");
+        steps.iAddConsiderRegionXPath("//main");
+        steps.iAddConsiderRegionAccessibilityId("content");
+        steps.iAddCustomIgnoreRegion(0, 100, 0, 200);
+        steps.iAddCustomConsiderRegion(10, 50, 10, 150);
+        steps.iTakeScreenshotWithOptions("Regions");
+        ArgumentCaptor<ScreenshotOptions> captor = ArgumentCaptor.forClass(ScreenshotOptions.class);
+        verify(mockPercy).screenshot(eq("Regions"), captor.capture());
+        ScreenshotOptions opts = captor.getValue();
+        assertEquals(1, opts.getIgnoreRegionXpaths().size());
+        assertEquals(1, opts.getIgnoreRegionAccessibilityIds().size());
+        assertEquals(1, opts.getConsiderRegionXpaths().size());
+        assertEquals(1, opts.getConsiderRegionAccessibilityIds().size());
+        assertEquals(1, opts.getCustomIgnoreRegions().size());
+        assertEquals(1, opts.getCustomConsiderRegions().size());
+    }
+
+    // ------------------------------------------------------------------
+    // Then step tests
+    // ------------------------------------------------------------------
+
     @Test(expected = IllegalStateException.class)
     public void testPercyShouldBeEnabledThrowsWithoutInit() {
         steps.percyShouldBeEnabled();
@@ -213,11 +345,5 @@ public class PercyStepsTest {
     public void testPercyShouldBeEnabledSucceeds() {
         PercySteps.setDriver(mockDriver);
         steps.percyShouldBeEnabled();
-    }
-
-    @Test
-    public void testSetThTestCaseExecutionId() {
-        PercySteps.setDriver(mockDriver);
-        steps.iSetThTestCaseExecutionId("exec-123");
     }
 }

--- a/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
+++ b/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
@@ -1,0 +1,208 @@
+package io.percy.appium.cucumber;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.appium.java_client.android.AndroidDriver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
+public class PercyStepsTest {
+
+    @Mock
+    AndroidDriver mockDriver;
+
+    private PercySteps steps;
+
+    @Before
+    public void setUp() {
+        mockDriver = mock(AndroidDriver.class);
+        steps = new PercySteps();
+    }
+
+    @After
+    public void tearDown() {
+        PercySteps.reset();
+    }
+
+    @Test
+    public void testSetDriverAndGetPercy() {
+        PercySteps.setDriver(mockDriver);
+        assertNotNull(PercySteps.getPercy());
+    }
+
+    @Test
+    public void testResetClearsState() {
+        PercySteps.setDriver(mockDriver);
+        assertNotNull(PercySteps.getPercy());
+
+        PercySteps.reset();
+        assertNull(PercySteps.getPercy());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIHaveAPercyInstanceThrowsWithoutDriver() {
+        steps.iHaveAPercyInstance();
+    }
+
+    @Test
+    public void testIHaveAPercyInstanceSucceedsWithDriver() {
+        PercySteps.setDriver(mockDriver);
+        steps.iHaveAPercyInstance();
+        assertNotNull(PercySteps.getPercy());
+    }
+
+    @Test
+    public void testSetDeviceName() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetDeviceName("iPhone 14");
+    }
+
+    @Test
+    public void testSetOrientation() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetOrientation("landscape");
+    }
+
+    @Test
+    public void testSetStatusBarHeight() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetStatusBarHeight(44);
+    }
+
+    @Test
+    public void testSetNavBarHeight() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetNavBarHeight(48);
+    }
+
+    @Test
+    public void testSetFullPage() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetFullPage("true");
+    }
+
+    @Test
+    public void testSetScreenLengths() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetScreenLengths(3);
+    }
+
+    @Test
+    public void testSetTestCase() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetTestCase("TC-001");
+    }
+
+    @Test
+    public void testSetLabels() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetLabels("regression,smoke");
+    }
+
+    @Test
+    public void testSetSync() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetSync("true");
+    }
+
+    @Test
+    public void testSetScrollableXpath() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetScrollableXpath("//android.widget.ScrollView");
+    }
+
+    @Test
+    public void testSetScrollableId() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetScrollableId("scrollview_1");
+    }
+
+    @Test
+    public void testSetTopScrollviewOffset() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetTopScrollviewOffset(100);
+    }
+
+    @Test
+    public void testSetBottomScrollviewOffset() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetBottomScrollviewOffset(50);
+    }
+
+    @Test
+    public void testSetScrollSpeed() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetScrollSpeed(200);
+    }
+
+    @Test
+    public void testSetAndroidScrollAreaPercentage() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetAndroidScrollAreaPercentage(80);
+    }
+
+    @Test
+    public void testAddIgnoreRegionXPath() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddIgnoreRegionXPath("//android.widget.Button[@text='AD']");
+    }
+
+    @Test
+    public void testAddIgnoreRegionAccessibilityId() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddIgnoreRegionAccessibilityId("ad_banner");
+    }
+
+    @Test
+    public void testAddConsiderRegionXPath() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddConsiderRegionXPath("//android.widget.TextView");
+    }
+
+    @Test
+    public void testAddConsiderRegionAccessibilityId() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddConsiderRegionAccessibilityId("main_content");
+    }
+
+    @Test
+    public void testAddCustomIgnoreRegion() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddCustomIgnoreRegion(0, 100, 0, 200);
+    }
+
+    @Test
+    public void testAddCustomConsiderRegion() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddCustomConsiderRegion(10, 50, 10, 150);
+    }
+
+    @Test
+    public void testClearPercyOptions() {
+        PercySteps.setDriver(mockDriver);
+        steps.iAddIgnoreRegionXPath("//button");
+        steps.iClearPercyOptions();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPercyShouldBeEnabledThrowsWithoutInit() {
+        steps.percyShouldBeEnabled();
+    }
+
+    @Test
+    public void testPercyShouldBeEnabledSucceeds() {
+        PercySteps.setDriver(mockDriver);
+        steps.percyShouldBeEnabled();
+    }
+
+    @Test
+    public void testSetThTestCaseExecutionId() {
+        PercySteps.setDriver(mockDriver);
+        steps.iSetThTestCaseExecutionId("exec-123");
+    }
+}

--- a/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
+++ b/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.SessionId;
 
 import java.net.MalformedURLException;
@@ -26,6 +27,9 @@ public class PercyStepsTest {
     public void setUp() {
         mockDriver = mock(AndroidDriver.class);
         when(mockDriver.getSessionId()).thenReturn(new SessionId("test-session-id"));
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        when(mockDriver.getCapabilities()).thenReturn(capabilities);
         try {
             lenient().when(mockDriver.getRemoteAddress())
                 .thenReturn(new URL("https://hub.example.com/wd/hub"));

--- a/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
+++ b/src/test/java/io/percy/appium/cucumber/PercyStepsTest.java
@@ -9,6 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.openqa.selenium.remote.SessionId;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class PercyStepsTest {
@@ -21,6 +25,13 @@ public class PercyStepsTest {
     @Before
     public void setUp() {
         mockDriver = mock(AndroidDriver.class);
+        when(mockDriver.getSessionId()).thenReturn(new SessionId("test-session-id"));
+        try {
+            lenient().when(mockDriver.getRemoteAddress())
+                .thenReturn(new URL("https://hub.example.com/wd/hub"));
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
         steps = new PercySteps();
     }
 


### PR DESCRIPTION
## Summary
- Add `PercySteps` class in `io.percy.appium.cucumber` package with Gherkin step definitions for Percy Screenshot with Appium
- Add `setClientInfo`/`setEnvironmentInfo` to Percy and Environment for framework wrapper identification
- Expose `CliWrapper.getEnvironment()` for client info override
- Cucumber dependency is `provided` scope -- users bring their own version

## Cucumber Steps

### Screenshot
```gherkin
When I take a Percy screenshot named "Homepage"
When I take a Percy screenshot named "Full Page" with full page
When I take a Percy screenshot named "With Options" with options
```

### Ignore/Consider Regions
```gherkin
Given I add ignore region XPath "//android.widget.Button[@text='AD']"
Given I add ignore region accessibility ID "ad-banner"
Given I add consider region XPath "//android.widget.LinearLayout[@content-desc='main']"
```

### Device Config
```gherkin
Given I set device name "Samsung Galaxy S22"
Given I set orientation "portrait"
Given I set status bar height 50
Given I set full page to "true"
Given I set labels "smoke,regression"
Given I set test case "TC-001"
```

### Setup
```java
@Before
public void setUp() {
    AppiumDriver driver = new AndroidDriver(url, caps);
    PercySteps.setDriver(driver);  // auto-sets cucumber env info
}

@After
public void tearDown() {
    PercySteps.reset();
}
```

## Test plan
- [ ] Unit tests pass
- [ ] Compile with Cucumber 7.x provided dependency
- [ ] Verify steps work in a Cucumber feature file with Percy exec
- [ ] Build info shows `percy-cucumber-java-appium/<version>` and `cucumber-java/<version>; appium-java`


🤖 Generated with [Claude Code](https://claude.com/claude-code)