### PR TITLE
fix: add appium: prefix fallback and null safety for capability access

### DIFF
--- a/src/main/java/io/percy/appium/metadata/AndroidMetadata.java
+++ b/src/main/java/io/percy/appium/metadata/AndroidMetadata.java
@@ -24,11 +24,11 @@ public class AndroidMetadata extends Metadata {
         if (deviceName != null) {
             return deviceName;
         }
-        Object device = driver.getCapabilities().getCapability("device");
+        Object device = getCapabilityValue("device");
 
         // Try desired capabilities (legacy format)
         if (device == null) {
-            Map desiredCaps = (Map) driver.getCapabilities().getCapability("desired");
+            Map desiredCaps = (Map) getCapabilityValue("desired");
             if (desiredCaps != null) {
                 device = desiredCaps.get("deviceName");
             }
@@ -36,14 +36,14 @@ public class AndroidMetadata extends Metadata {
 
         // For espresso driver
         if (device == null) {
-            device = driver.getCapabilities().getCapability("appium:deviceName");
+            device = getCapabilityValue("deviceName");
         }
-        return device.toString();
+        return device != null ? device.toString() : "";
     }
 
     public Integer deviceScreenWidth() {
         // Try deviceScreenSize from capabilities
-        Object screenSize = driver.getCapabilities().getCapability("deviceScreenSize");
+        Object screenSize = getCapabilityValue("deviceScreenSize");
         if (screenSize != null) {
             return Integer.parseInt(screenSize.toString().split("x")[0]);
         }
@@ -64,7 +64,7 @@ public class AndroidMetadata extends Metadata {
 
     public Integer deviceScreenHeight() {
         // Try deviceScreenSize from capabilities
-        Object screenSize = driver.getCapabilities().getCapability("deviceScreenSize");
+        Object screenSize = getCapabilityValue("deviceScreenSize");
         if (screenSize != null) {
             return Integer.parseInt(screenSize.toString().split("x")[1]);
         }
@@ -139,7 +139,7 @@ public class AndroidMetadata extends Metadata {
 
     private Map getViewportRect() {
         if (Cache.CACHE_MAP.get("viewportRect_" + sessionId) == null) {
-            Cache.CACHE_MAP.put("viewportRect_" + sessionId, driver.getCapabilities().getCapability("viewportRect"));
+            Cache.CACHE_MAP.put("viewportRect_" + sessionId, getCapabilityValue("viewportRect"));
         }
         return (Map) Cache.CACHE_MAP.get("viewportRect_" + sessionId);
     }

--- a/src/main/java/io/percy/appium/metadata/IosMetadata.java
+++ b/src/main/java/io/percy/appium/metadata/IosMetadata.java
@@ -23,11 +23,17 @@ public class IosMetadata extends Metadata {
         if (deviceName != null) {
             return deviceName;
         }
-        return driver.getCapabilities().getCapability("deviceName").toString();
+        Object value = getCapabilityValue("deviceName");
+        if (value == null) {
+            value = getCapabilityValue("device");
+        }
+        return value != null ? value.toString() : "";
     }
 
     public String osName() {
-        String osName = driver.getCapabilities().getCapability("platformName").toString();
+        Object platformName = getCapabilityValue("platformName");
+        if (platformName == null) return "iOS";
+        String osName = platformName.toString();
         return osName.substring(0, 1).toLowerCase() + osName.substring(1).toUpperCase();
     }
 

--- a/src/main/java/io/percy/appium/metadata/Metadata.java
+++ b/src/main/java/io/percy/appium/metadata/Metadata.java
@@ -1,11 +1,19 @@
 package io.percy.appium.metadata;
 
+import java.util.Set;
+
 import org.openqa.selenium.ScreenOrientation;
 
 import io.appium.java_client.AppiumDriver;
 
 public abstract class Metadata {
-    private AppiumDriver driver;
+    protected AppiumDriver driver;
+
+    private static final Set<String> W3C_STANDARD_CAPS = Set.of(
+        "browserName", "browserVersion", "platformName",
+        "acceptInsecureCerts", "pageLoadStrategy", "proxy",
+        "timeouts", "unhandledPromptBehavior"
+    );
     protected String orientation;
     protected String platformVersion;
     protected Integer statusBar;
@@ -24,8 +32,19 @@ public abstract class Metadata {
         this.sessionId = driver.getSessionId().toString();
     }
 
+    protected Object getCapabilityValue(String key) {
+        if (W3C_STANDARD_CAPS.contains(key)) {
+            return driver.getCapabilities().getCapability(key);
+        }
+        Object val = driver.getCapabilities().getCapability(key);
+        if (val != null) return val;
+        return driver.getCapabilities().getCapability("appium:" + key);
+    }
+
     public String osName() {
-        String osName = driver.getCapabilities().getCapability("platformName").toString();
+        Object platformName = getCapabilityValue("platformName");
+        if (platformName == null) return "";
+        String osName = platformName.toString();
         return osName.substring(0, 1).toUpperCase() + osName.substring(1).toLowerCase();
     }
 
@@ -33,9 +52,9 @@ public abstract class Metadata {
         if (platformVersion != null) {
             return platformVersion;
         }
-        Object osVersion = driver.getCapabilities().getCapability("platformVersion");
+        Object osVersion = getCapabilityValue("platformVersion");
         if (osVersion == null) {
-            osVersion = driver.getCapabilities().getCapability("os_version");
+            osVersion = getCapabilityValue("os_version");
             if (osVersion == null) {
                 return null;
             }
@@ -69,7 +88,7 @@ public abstract class Metadata {
                 return "portrait";
             }
         } else {
-            Object orientationCapability = driver.getCapabilities().getCapability("orientation");
+            Object orientationCapability = getCapabilityValue("orientation");
             if (orientationCapability != null) {
                 return orientationCapability.toString().toLowerCase();
             } else {


### PR DESCRIPTION
## Summary
- Add `getCapabilityValue()` helper in `Metadata.java` that tries bare key first, then `appium:`-prefixed key for Appium 2.x W3C protocol compatibility
- Fix NPE risks on `.toString()` calls when capabilities are null (e.g. iOS BrowserStack sessions where `desired`/`platformVersion`/`deviceName` may be missing)
- Use `getCapabilityValue()` consistently across `AndroidMetadata` and `IosMetadata` instead of direct `driver.getCapabilities().getCapability()` calls

## What was broken
On iOS BrowserStack real device sessions:
- `desired` capability is undefined → `getCapability("desired")` returns null
- `platformVersion` bare key is missing → only accessible via `appium:platformVersion`
- `deviceName` may not resolve without `appium:` prefix

On Appium 2.x W3C protocol:
- Non-standard capabilities require `appium:` prefix which BrowserStack may or may not return

## Changes
| File | Change |
|------|--------|
| `Metadata.java` | Added `getCapabilityValue()` with W3C standard caps awareness and `appium:` prefix fallback. Fixed `osName()` NPE. |
| `AndroidMetadata.java` | Migrated all capability access to `getCapabilityValue()`. Added null safety on `device.toString()`. |
| `IosMetadata.java` | Migrated to `getCapabilityValue()` with `device` fallback. Null-safe `osName()` and `deviceName()`. |

## Test plan
- [ ] Run existing test suite to verify no regressions
- [ ] Test with Appium 1.x session (JSONWP protocol) — verify bare keys still work
- [ ] Test with Appium 2.x session (W3C protocol) — verify `appium:` prefix fallback works
- [ ] Test with iOS BrowserStack session — verify no NPE when `desired` is undefined

🤖 Generated with [Claude Code](https://claude.ai/code)