### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-appium-app</artifactId>
-  <version>2.2.2-alpha.2</version>
+  <version>2.3.0</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
## Summary
- Bump version from 2.2.2-alpha.2 to 2.3.0 for Cucumber support release

🤖 Generated with [Claude Code](https://claude.com/claude-code)