### PR TITLE
fix: add explicit jsr305 dep for java-client 9.x/10.x compatibility (PER-7786)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,16 @@
     <!--
       Provides javax.annotation.Nullable. java-client 8.x pulled this in
       transitively, but java-client 9.x/10.x dropped that transitive
-      dependency. Declaring it explicitly keeps the SDK compiling and running
-      against all major java-client versions (8, 9, 10).
+      dependency. Declaring it explicitly keeps the SDK compiling against all
+      major java-client versions (8, 9, 10). Scope is "provided": @Nullable has
+      CLASS retention (compile-only), so it is not needed at runtime and should
+      not leak onto consumers' classpath as a transitive compile dependency.
     -->
     <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,17 @@
         <artifactId>java-client</artifactId>
         <version>8.6.0</version>
     </dependency>
+    <!--
+      Provides javax.annotation.Nullable. java-client 8.x pulled this in
+      transitively, but java-client 9.x/10.x dropped that transitive
+      dependency. Declaring it explicitly keeps the SDK compiling and running
+      against all major java-client versions (8, 9, 10).
+    -->
+    <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+    </dependency>
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>


### PR DESCRIPTION
## What
java-client 8.x supplied `javax.annotation.Nullable` transitively; **java-client 9.x/10.x dropped it**, so the SDK no longer compiles (`@Nullable` in `AppAutomate`/`ScreenshotOptions`) against modern clients.

## Fix
Declare `com.google.code.findbugs:jsr305:3.0.2` explicitly. One line, no source changes, keeps the **Java 8 floor** (no java-client version bump — java-client 10 requires Java 11+).

## Validation
- Unit suite: **139/139** on java-client **8.6.0** *and* **10.1.1**.
- End-to-end on BrowserStack App Automate: java-client **7.6.0 / 8.6.0 / 9.5.0** × Appium servers **1.22.0** and **2.15.0** → **5/5 passed** (valid pairings; client 7 is JSONWP-only).

Note: java-client **9.x + the newest Selenium** has an unrelated upstream issue (`SupportsContextSwitching` references the removed `org.openqa.selenium.ContextAware`); 8.x and 10.x are unaffected. This PR is the SDK-side fix.

Part of PER-7786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)