### PR TITLE
Bump SDK version to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-appium-app</artifactId>
-  <version>2.3.1-beta.0</version>
+  <version>2.3.1</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -4,7 +4,7 @@ import io.appium.java_client.AppiumDriver;
 
 public class Environment {
     private AppiumDriver driver;
-    public static final String SDK_VERSION = "2.3.1-beta.0";
+    public static final String SDK_VERSION = "2.3.1";
     private static final String SDK_NAME = "percy-appium-app";
     private static String percyBuildID;
     private static String percyBuildUrl;


### PR DESCRIPTION
Stable release **2.3.1** (PER-7786). Promotes 2.3.1-beta.0 after beta validation.

- `pom.xml` + `Environment.java`: 2.3.1-beta.0 → 2.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)