### PR TITLE
release v2.3.2-beta.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.percy</groupId>
   <artifactId>percy-appium-app</artifactId>
-  <version>2.3.1</version>
+  <version>2.3.2-beta.0</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/percy/appium/Environment.java
+++ b/src/main/java/io/percy/appium/Environment.java
@@ -4,7 +4,7 @@ import io.appium.java_client.AppiumDriver;
 
 public class Environment {
     private AppiumDriver driver;
-    public static final String SDK_VERSION = "2.3.1";
+    public static final String SDK_VERSION = "2.3.2-beta.0";
     private static final String SDK_NAME = "percy-appium-app";
     private static String percyBuildID;
     private static String percyBuildUrl;


### PR DESCRIPTION
Bumps the SDK to the next beta (`2.3.1` → `2.3.2-beta.0`) for a beta release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)